### PR TITLE
Add null-check to prevent fatal error

### DIFF
--- a/lazysizes.php
+++ b/lazysizes.php
@@ -65,7 +65,11 @@ class LazysizesPlugin extends Plugin {
             $Inline = $this->inlineImage($Excerpt);
             $InlineOriginal = parent::inlineImage($Excerpt);
 
-            $imageData = getOriginalImage($InlineOriginal['element']['attributes']['src'], $images);
+            if ($InlineOriginal !== null) {
+                $imageData = getOriginalImage($InlineOriginal['element']['attributes']['src'], $images);
+            } else {
+                $imageData = null;
+            }
 
             return manipulateElement($Inline, $imageData, $config);
         };  


### PR DESCRIPTION
Hi, first of all thanks for the handy plugin!

I ran into an issue where sometimes the site would break with a fatal error. This happens when the markdown parser invokes the callback without an actual image link. Placing a `!` on a line by itself triggers this behaviour.